### PR TITLE
feat: lp slider now works on guidescope

### DIFF
--- a/telescope/Menu/DateTime/datetime.js
+++ b/telescope/Menu/DateTime/datetime.js
@@ -124,7 +124,7 @@ function showTimeSelector() {
     onClose: () => (isUserTouchingCalendar = false),
 
     onValueUpdate: function (selectedDates) {
-      console.log("Called onValueUpdate function");
+      // console.log("Called onValueUpdate function");
       if (selectedDates.length > 0) {
         // fecha seleccionada siempre respecto al huso local
         const date = selectedDates[0];

--- a/telescope/utils/values.js
+++ b/telescope/utils/values.js
@@ -191,7 +191,7 @@ for (let element of seeingSliders) {
 interactionSection.appendChild(seeingSection);
 
 function sendSeeingValue({ target, value }) {
-  console.log('****************Seeing:', target, value)
+  // console.log('****************Seeing:', target, value)
   Protobject.Core.send({ msg: 'seeingOption', values: { target, value } }).to("index.html");
 }
 
@@ -214,6 +214,9 @@ pollutionInput.addEventListener("input", () => {
 
   const skyMag = bortleToMag(parseInt(pollution));
 
+  // To guidescope
+  applyPollution({ mag: skyMag });
+  // To telescope
   Protobject.Core.send({ msg: "updatePollution", values: { mag: skyMag } }).to("index.html");
   // Protobject.Core.send({msg:"updatePollution", values: { bortle: pollutionInput.value }}).to("Lamp.html");
 });

--- a/util/protobject.js
+++ b/util/protobject.js
@@ -23,7 +23,7 @@ Protobject.Core.onReceived((data) => {
     const targetFunction = functionMap[msg];
 
     if (typeof targetFunction === "function") {
-      console.log(`Ejecutando función: ${msg} con valores:`, values);
+      // console.log(`Ejecutando función: ${msg} con valores:`, values);
       targetFunction(values);
     }
   } else {


### PR DESCRIPTION
This pull request primarily removes debugging `console.log` statements from several JavaScript files to clean up the codebase and reduce unnecessary console output. Additionally, it introduces a minor update to the pollution value handling logic. The most important changes are grouped below:

**Code cleanup:**

* Commented out `console.log` statements in the `onValueUpdate` callback within `datetime.js` to prevent logging during date selection.
* Commented out `console.log` statements in the `sendSeeingValue` function in `values.js`, reducing console clutter during seeing value updates.
* Commented out a `console.log` statement in the `onReceived` handler in `protobject.js` to avoid logging function execution details.

**Logic update:**

* Added a call to `applyPollution` in the pollution input event handler in `values.js` to ensure the pollution value is applied to the guidescope, in addition to sending the update to the telescope.