### PR TITLE
fix: change wrong data source target from stars to dss

### DIFF
--- a/util/initStel.js
+++ b/util/initStel.js
@@ -85,7 +85,7 @@ export default function initializeStelEngine(isTelescope = false) {
                     })
                 );
                 dataSourcePromises.push(
-                    core.stars.addDataSource({
+                    core.dss.addDataSource({
                         url: baseUrlBig + "surveys/gaia/v1",
                         key: "gaia",
                     })


### PR DESCRIPTION
This pull request updates the initialization logic for data sources in the `initializeStelEngine` function. The main change is that the Gaia survey data source is now added to `core.dss` instead of `core.stars`, which likely reflects a more accurate categorization of this data source.

Data source initialization update:

* In `util/initStel.js`, the Gaia survey data source is now registered with `core.dss.addDataSource` instead of `core.stars.addDataSource`, ensuring it is managed under the correct subsystem.